### PR TITLE
make sure that log message is converted to bitstring before term_to_binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ You can pass the backend the following configuration (shown are the defaults):
           {amqp_pass,   <<"guest">>},
           {amqp_vhost,  <<"/">>},
           {amqp_host,   "localhost"},
-          {amqp_port,   5672}
+          {amqp_port,   5672},
+          {routing_key, <<"YourRoutingKey">>}
         ]}
       ]}
     ]}

--- a/src/lager_amqp_backend.erl
+++ b/src/lager_amqp_backend.erl
@@ -229,7 +229,7 @@ log(#state{params = AmqpParams } = State, {Date, Time}, Level, Message) ->
             Node = atom_to_list(node()),
             Level1 = atom_to_list(lager_util:num_to_level(Level)),
             send(State, Node, Level,
-                 term_to_binary([Date, Time, Node, Level1, Message]),
+                 term_to_binary([Date, Time, Node, Level1, list_to_binary(Message)]),
                  Channel);
         _ ->
             State


### PR DESCRIPTION
the log message which goes into AMQP queue is an erlang binary. To consume it from from any language other than erlang one needs to implement a convention from Erlang External Term Format (or use some existing implementation). The issue is it is impossible to tell a regular list from a string if a message string is not bitstring. so if you log message contains any non-printable characters, you will get garbage. So, better to make sure that log message is always a bitstring
